### PR TITLE
remove the wrong static annotation on `dice_loss`

### DIFF
--- a/mmseg/models/losses/dice_loss.py
+++ b/mmseg/models/losses/dice_loss.py
@@ -36,7 +36,7 @@ def dice_loss(pred: torch.Tensor,
               reduction: Union[str, None] = 'mean',
               naive_dice: Union[bool, None] = False,
               avg_factor: Union[int, None] = None,
-              ignore_index: Union[int, None] = 255):
+              ignore_index: Union[int, None] = 255) -> torch.Tensor:
     """Calculate dice loss, there are two forms of dice loss is supported:
 
         - the one proposed in `V-Net: Fully Convolutional Neural

--- a/mmseg/models/losses/dice_loss.py
+++ b/mmseg/models/losses/dice_loss.py
@@ -36,7 +36,7 @@ def dice_loss(pred: torch.Tensor,
               reduction: Union[str, None] = 'mean',
               naive_dice: Union[bool, None] = False,
               avg_factor: Union[int, None] = None,
-              ignore_index: Union[int, None] = 255) -> float:
+              ignore_index: Union[int, None] = 255):
     """Calculate dice loss, there are two forms of dice loss is supported:
 
         - the one proposed in `V-Net: Fully Convolutional Neural


### PR DESCRIPTION
`dice_loss` returns the `Tensor` object from `weight_reduce_loss`. So the static return annotation is not `float`, deleting it can let python to auto determine the return type.