### PR TITLE
Fix inaccurate implementation of MSCAN

### DIFF
--- a/mmseg/models/backbones/mscan.py
+++ b/mmseg/models/backbones/mscan.py
@@ -401,7 +401,7 @@ class MSCAN(BaseModule):
 
         for i in range(num_stages):
             if i == 0:
-                patch_embed = StemConv(3, embed_dims[0], norm_cfg=norm_cfg)
+                patch_embed = StemConv(in_channels, embed_dims[0], norm_cfg=norm_cfg)
             else:
                 patch_embed = OverlapPatchEmbed(
                     patch_size=7 if i == 0 else 3,

--- a/mmseg/models/backbones/mscan.py
+++ b/mmseg/models/backbones/mscan.py
@@ -401,7 +401,8 @@ class MSCAN(BaseModule):
 
         for i in range(num_stages):
             if i == 0:
-                patch_embed = StemConv(in_channels, embed_dims[0], norm_cfg=norm_cfg)
+                patch_embed = StemConv(
+                    in_channels, embed_dims[0], norm_cfg=norm_cfg)
             else:
                 patch_embed = OverlapPatchEmbed(
                     patch_size=7 if i == 0 else 3,


### PR DESCRIPTION
The MSCAN's stem layer's `in_channels` should align to the overall `in_channels`, which will cause input violation during the forward.

Without this fix, `MSCAN` can only be used with `in_channels=3`, also the default setting.